### PR TITLE
return specific error on delete when no row is affected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 example/example
+.idea

--- a/db.go
+++ b/db.go
@@ -164,7 +164,9 @@ func (db *DB) doDelete(engine Engine, s MappedStruct) error {
 	if err != nil {
 		return err
 	}
-	if rowsAffected != 1 {
+	if rowsAffected == 0 {
+		return ErrRecordNotFound
+	} else if rowsAffected != 1 {
 		return fmt.Errorf("Wrong number of rows affected. Expected 1, got %v", rowsAffected)
 	}
 	db.Callbacks.AfterDelete.Call(db, s)


### PR DESCRIPTION
This does not technically change anything but enables users to catch specific cases where the given id was unknown in DB separately from other error reasons...